### PR TITLE
Fix proxy_libintl for QNX; Nuke snapshot=off

### DIFF
--- a/Makefile.sdk.mk
+++ b/Makefile.sdk.mk
@@ -250,7 +250,7 @@ ifeq ($(host_platform), linux)
 	v8_libs_private := " -lm"
 endif
 ifeq ($(host_platform), qnx)
-	v8_host_flags := -f make-qnx -D snapshot=off
+	v8_host_flags := -f make-qnx
 endif
 ifeq ($(host_platform), android)
 	v8_flavor_prefix := android_

--- a/releng/config.site.in
+++ b/releng/config.site.in
@@ -154,7 +154,7 @@ case "$PACKAGE_TARNAME" in
     esac
 
     case $frida_host_platform in
-      linux|android|mac|ios)
+      linux|android|mac|ios|qnx)
         enable_proxy_libintl=yes
       ;;
     esac


### PR DESCRIPTION
Use enable_proxy_libintl to avoid dependence on gettext when
compiling for QNX.

Turn off the snapshot=off for QNX