### PR TITLE
Add umoddi3 libc-compat implementation for QNX

### DIFF
--- a/Makefile.linux.mk
+++ b/Makefile.linux.mk
@@ -126,6 +126,7 @@ check-gum-64: build/frida-linux-x86_64/lib/pkgconfig/frida-gum-1.0.pc build/frid
 core-32: build/frida-linux-i386/lib/pkgconfig/frida-core-1.0.pc ##@core Build for i386
 core-64: build/frida-linux-x86_64/lib/pkgconfig/frida-core-1.0.pc ##@core Build for x86-64
 core-android: build/frida-android-arm/lib/pkgconfig/frida-core-1.0.pc ##@core Build for Android
+core-qnx-arm: build/frida-qnx-arm/lib/pkgconfig/frida-core-1.0.pc ##@core Build for QNX-arm
 
 frida-core/configure: build/frida-env-linux-$(build_arch).rc frida-core/configure.ac
 	. build/frida-env-linux-$(build_arch).rc && cd frida-core && ./autogen.sh
@@ -211,6 +212,7 @@ check-core-64: build/tmp-linux-x86_64/frida-core/tests/frida-tests build/frida-c
 server-32: build/frida_stripped-linux-i386/bin/frida-server ##@server Build for i386
 server-64: build/frida_stripped-linux-x86_64/bin/frida-server ##@server Build for x86-64
 server-android: build/frida_stripped-android-arm/bin/frida-server ##@server Build for Android
+server-qnx-arm: build/frida_stripped-qnx-arm/bin/frida-server ##@server Build for QNX-arm
 
 build/frida_stripped-%/bin/frida-server: build/frida-%/bin/frida-server
 	mkdir -p $(@D)

--- a/releng/libc-compat/umoddi3.c
+++ b/releng/libc-compat/umoddi3.c
@@ -1,24 +1,29 @@
 typedef unsigned long long      uint64_t;
 typedef signed long long        int64_t;
 
-uint64_t __udivmoddi4(uint64_t num, uint64_t den, uint64_t *rem_p)
+uint64_t
+__udivmoddi4 (uint64_t num, uint64_t den, uint64_t *rem_p)
 {
   uint64_t quot = 0, qbit = 1;
 
-  if ( den == 0 ) {
+  if (den == 0)
+  {
     return 1/((unsigned)den); /* Intentional divide by zero, without
                                  triggering a compiler warning which
                                  would abort the build */
   }
 
   /* Left-justify denominator and count shift */
-  while ( (int64_t)den >= 0 ) {
+  while ((int64_t)den >= 0)
+  {
     den <<= 1;
     qbit <<= 1;
   }
 
-  while ( qbit ) {
-    if ( den <= num ) {
+  while (qbit)
+  {
+    if (den <= num)
+    {
       num -= den;
       quot += qbit;
     }
@@ -26,16 +31,17 @@ uint64_t __udivmoddi4(uint64_t num, uint64_t den, uint64_t *rem_p)
     qbit >>= 1;
   }
 
-  if ( rem_p )
+  if (rem_p != NULL)
     *rem_p = num;
 
   return quot;
 }
 
-uint64_t __umoddi3(uint64_t num, uint64_t den)
+uint64_t
+__umoddi3 (uint64_t num, uint64_t den)
 {
   uint64_t v;
 
-  (void) __udivmoddi4(num, den, &v);
+  (void) __udivmoddi4 (num, den, &v);
   return v;
 }

--- a/releng/libc-compat/umoddi3.c
+++ b/releng/libc-compat/umoddi3.c
@@ -8,7 +8,7 @@ __udivmoddi4 (uint64_t num, uint64_t den, uint64_t *rem_p)
 
   if (den == 0)
   {
-    return 1/((unsigned) den); /* Intentional divide by zero, without
+    return 1 / ((unsigned) den); /* Intentional divide by zero, without
                                  triggering a compiler warning which
                                  would abort the build */
   }

--- a/releng/libc-compat/umoddi3.c
+++ b/releng/libc-compat/umoddi3.c
@@ -8,13 +8,13 @@ __udivmoddi4 (uint64_t num, uint64_t den, uint64_t *rem_p)
 
   if (den == 0)
   {
-    return 1/((unsigned)den); /* Intentional divide by zero, without
+    return 1/((unsigned) den); /* Intentional divide by zero, without
                                  triggering a compiler warning which
                                  would abort the build */
   }
 
   /* Left-justify denominator and count shift */
-  while ((int64_t)den >= 0)
+  while ((int64_t) den >= 0)
   {
     den <<= 1;
     qbit <<= 1;

--- a/releng/libc-compat/umoddi3.c
+++ b/releng/libc-compat/umoddi3.c
@@ -1,0 +1,41 @@
+typedef unsigned long long      uint64_t;
+typedef signed long long        int64_t;
+
+uint64_t __udivmoddi4(uint64_t num, uint64_t den, uint64_t *rem_p)
+{
+  uint64_t quot = 0, qbit = 1;
+
+  if ( den == 0 ) {
+    return 1/((unsigned)den); /* Intentional divide by zero, without
+                                 triggering a compiler warning which
+                                 would abort the build */
+  }
+
+  /* Left-justify denominator and count shift */
+  while ( (int64_t)den >= 0 ) {
+    den <<= 1;
+    qbit <<= 1;
+  }
+
+  while ( qbit ) {
+    if ( den <= num ) {
+      num -= den;
+      quot += qbit;
+    }
+    den >>= 1;
+    qbit >>= 1;
+  }
+
+  if ( rem_p )
+    *rem_p = num;
+
+  return quot;
+}
+
+uint64_t __umoddi3(uint64_t num, uint64_t den)
+{
+  uint64_t v;
+
+  (void) __udivmoddi4(num, den, &v);
+  return v;
+}

--- a/releng/setup-env.sh
+++ b/releng/setup-env.sh
@@ -307,10 +307,11 @@ case $host_platform in
     CFLAGS="-ffunction-sections -fdata-sections"
     LDFLAGS="-Wl,--no-undefined -Wl,--gc-sections -L$(dirname $qnx_sysroot/lib/gcc/4.8.3/libstdc++.a)"
     if [ $host_arch == "arm" ]; then
-      # The __modsi3 function is not available in all libc.so
+      # The __modsi3 and __umoddi3 functions are not available in all libc.so
       mkdir -p $FRIDA_PREFIX_LIB
       $CC $CFLAGS -c $FRIDA_ROOT/releng/libc-compat/modsi3.c -O0 -o $FRIDA_PREFIX_LIB/modsi3.o
-      $AR rcs $FRIDA_PREFIX_LIB/libfrida-libc-compat.a $FRIDA_PREFIX_LIB/modsi3.o
+      $CC $CFLAGS -c $FRIDA_ROOT/releng/libc-compat/umoddi3.c -O0 -o $FRIDA_PREFIX_LIB/umoddi3.o
+      $AR rcs $FRIDA_PREFIX_LIB/libfrida-libc-compat.a $FRIDA_PREFIX_LIB/modsi3.o $FRIDA_PREFIX_LIB/umoddi3.o
       LDFLAGS="$LDFLAGS -lfrida-libc-compat"
     fi
 


### PR DESCRIPTION
This symbol is also missing from some libc implementations.