### PR TITLE
node-pre-gyp -> prebuild (POC code)

### DIFF
--- a/releng/release.py
+++ b/releng/release.py
@@ -47,16 +47,17 @@ if __name__ == '__main__':
 
     def upload_to_npm(node, publish):
         node_bin_dir = os.path.dirname(node)
-        node_pre_gyp_bin_dir = os.path.join(frida_node_dir, "node_modules", "node-pre-gyp", "bin")
+        #node_pre_gyp_bin_dir = os.path.join(frida_node_dir, "node_modules", "node-pre-gyp", "bin")
         npm = os.path.join(node_bin_dir, "npm")
         if system == 'Windows':
             npm += '.cmd'
-        node_pre_gyp = os.path.join(node_pre_gyp_bin_dir, "node-pre-gyp")
-        if system == 'Windows':
-            node_pre_gyp += '.cmd'
+        #node_pre_gyp = os.path.join(node_pre_gyp_bin_dir, "node-pre-gyp")
+        #if system == 'Windows':
+            #node_pre_gyp += '.cmd'
         env = dict(os.environ)
         env.update({
-            'PATH': os.pathsep.join([node_pre_gyp_bin_dir, node_bin_dir]) + os.pathsep + os.getenv('PATH'),
+            #'PATH': os.pathsep.join([node_pre_gyp_bin_dir, node_bin_dir]) + os.pathsep + os.getenv('PATH'),
+            'PATH': node_bin_dir + os.pathsep + os.getenv('PATH'),
             'FRIDA': build_dir
         })
         def do(args):
@@ -73,18 +74,22 @@ if __name__ == '__main__':
         do([npm, "version", version])
         if publish:
             do([npm, "publish"])
-        do([npm, "install", "--build-from-source"])
-        if system == 'Darwin':
-            do(["strip", "-Sx", "build/Release/frida_binding.node"])
-            do(["strip", "-Sx", glob.glob(frida_node_dir + "/lib/binding/Release/node-*/frida_binding.node")[0]])
-        elif system == 'Linux':
-            do(["strip", "--strip-all", "build/Release/frida_binding.node"])
-            do(["strip", "--strip-all", glob.glob(frida_node_dir + "/lib/binding/Release/node-*/frida_binding.node")[0]])
-        do([node_pre_gyp, "package"])
-        package = glob.glob(os.path.join(frida_node_dir, "build", "stage", "node", "v*", "Release", "*.tar.gz"))[0]
-        remote_path = os.path.dirname(package[len(frida_node_dir) + 13:]).replace("\\", "/") + "/"
+        #do([npm, "install", "--build-from-source"])
+        do([npm, "run", "prebuild"])
+        #if system == 'Darwin':
+            #do(["strip", "-Sx", "build/Release/frida_binding.node"])
+            #do(["strip", "-Sx", glob.glob(frida_node_dir + "/lib/binding/Release/node-*/frida_binding.node")[0]])
+        #elif system == 'Linux':
+            #do(["strip", "--strip-all", "build/Release/frida_binding.node"])
+            #do(["strip", "--strip-all", glob.glob(frida_node_dir + "/lib/binding/Release/node-*/frida_binding.node")[0]])
+        #do([node_pre_gyp, "package"])
+        #package = glob.glob(os.path.join(frida_node_dir, "build", "stage", "node", "v*", "Release", "*.tar.gz"))[0]
+        packages = glob.glob(os.path.join(frida_node_dir, "prebuilds", "*.tar.gz"))
+        #remote_path = os.path.dirname(package[len(frida_node_dir) + 13:]).replace("\\", "/") + "/"
+        remote_path = os.path.dirname(packages[0][len(frida_node_dir) + 13:]).replace("\\", "/") + "/"
         do([ssh, "buildmaster@build.frida.re", "mkdir -p /home/buildmaster/public_html/" + remote_path])
-        do([scp, package, "buildmaster@build.frida.re:/home/buildmaster/public_html/" + remote_path])
+        #do([scp, package, "buildmaster@build.frida.re:/home/buildmaster/public_html/" + remote_path])
+        do([scp, packages, "buildmaster@build.frida.re:/home/buildmaster/public_html/" + remote_path])
         reset()
 
     def upload_ios_deb(server):


### PR DESCRIPTION
Note that this PR is a proof of concept just to illustrate. @oleavr You don't need to merge this PR if you don't want to, or you merge it and tweak it until it works. I'm unsure of the `remote_path` thing. Since `prebuild` builds for all abi version for the given node version `scp` could copy all `.tar.gz` files up to the build server.

Let me know if you have any questions.