### PR TITLE
Update to support execution in Python 3 environment

### DIFF
--- a/releng/generate-version-header.py
+++ b/releng/generate-version-header.py
@@ -37,7 +37,7 @@ def generate_version_header():
                     return
         except:
             pass
-        with open(output_filename, "wb") as f:
+        with open(output_filename, "w") as f:
             f.write(header)
 
 


### PR DESCRIPTION
Simple one character update to the generate-version-header.py script to support execution in Python 3 environments. (Strings are now Unicode.)