### PR TITLE
Add sdk support for linux-arm

### DIFF
--- a/Makefile.linux.mk
+++ b/Makefile.linux.mk
@@ -138,16 +138,39 @@ build/tmp-%/frida-core/Makefile: build/frida-env-%.rc frida-core/configure build
 	mkdir -p $(@D)
 	. build/frida-env-$*.rc && cd $(@D) && ../../../frida-core/configure
 
-build/frida-linux-%/lib/pkgconfig/frida-core-1.0.pc: build/tmp_stripped-linux-i386/frida-core/src/frida-helper build/tmp_stripped-linux-x86_64/frida-core/src/frida-helper build/tmp_stripped-linux-i386/frida-core/lib/agent/.libs/libfrida-agent.so build/tmp_stripped-linux-x86_64/frida-core/lib/agent/.libs/libfrida-agent.so
+build/frida-linux-i386/lib/pkgconfig/frida-core-1.0.pc: build/tmp_stripped-linux-i386/frida-core/src/frida-helper build/tmp_stripped-linux-x86_64/frida-core/src/frida-helper build/tmp_stripped-linux-arm/frida-core/src/frida-helper build/tmp_stripped-linux-i386/frida-core/lib/agent/.libs/libfrida-agent.so build/tmp_stripped-linux-x86_64/frida-core/lib/agent/.libs/libfrida-agent.so build/tmp_stripped-linux-arm/frida-core/lib/agent/.libs/libfrida-agent.so
 	@$(call ensure_relink,frida-core/src/frida.c,build/tmp-linux-$*/frida-core/src/libfrida_core_la-frida.lo)
-	. build/frida-env-linux-$*.rc \
-		&& cd build/tmp-linux-$*/frida-core \
+	. build/frida-env-linux-i386.rc \
+		&& cd build/tmp-linux-i386/frida-core \
 		&& make -C src install \
 			RESOURCE_COMPILER="\"$(FRIDA)/releng/resource-compiler-linux-$(build_arch)\" --toolchain=gnu" \
 			HELPER32=../../../../build/tmp_stripped-linux-i386/frida-core/src/frida-helper!frida-helper-32 \
 			HELPER64=../../../../build/tmp_stripped-linux-x86_64/frida-core/src/frida-helper!frida-helper-64 \
 			AGENT32=../../../../build/tmp_stripped-linux-i386/frida-core/lib/agent/.libs/libfrida-agent.so!frida-agent-32.so \
 			AGENT64=../../../../build/tmp_stripped-linux-x86_64/frida-core/lib/agent/.libs/libfrida-agent.so!frida-agent-64.so \
+		&& make install-data-am
+	@touch -c $@
+build/frida-linux-x86_64/lib/pkgconfig/frida-core-1.0.pc: build/tmp_stripped-linux-i386/frida-core/src/frida-helper build/tmp_stripped-linux-x86_64/frida-core/src/frida-helper build/tmp_stripped-linux-arm/frida-core/src/frida-helper build/tmp_stripped-linux-i386/frida-core/lib/agent/.libs/libfrida-agent.so build/tmp_stripped-linux-x86_64/frida-core/lib/agent/.libs/libfrida-agent.so build/tmp_stripped-linux-arm/frida-core/lib/agent/.libs/libfrida-agent.so
+	@$(call ensure_relink,frida-core/src/frida.c,build/tmp-linux-$*/frida-core/src/libfrida_core_la-frida.lo)
+	. build/frida-env-linux-x86_64.rc \
+		&& cd build/tmp-linux-x86_64/frida-core \
+		&& make -C src install \
+			RESOURCE_COMPILER="\"$(FRIDA)/releng/resource-compiler-linux-$(build_arch)\" --toolchain=gnu" \
+			HELPER32=../../../../build/tmp_stripped-linux-i386/frida-core/src/frida-helper!frida-helper-32 \
+			HELPER64=../../../../build/tmp_stripped-linux-x86_64/frida-core/src/frida-helper!frida-helper-64 \
+			AGENT32=../../../../build/tmp_stripped-linux-i386/frida-core/lib/agent/.libs/libfrida-agent.so!frida-agent-32.so \
+			AGENT64=../../../../build/tmp_stripped-linux-x86_64/frida-core/lib/agent/.libs/libfrida-agent.so!frida-agent-64.so \
+		&& make install-data-am
+	@touch -c $@
+build/frida-linux-arm/lib/pkgconfig/frida-core-1.0.pc: build/tmp_stripped-linux-arm/frida-core/src/frida-helper build/tmp_stripped-linux-arm/frida-core/lib/loader/.libs/libfrida-loader.so build/tmp_stripped-linux-arm/frida-core/lib/agent/.libs/libfrida-agent.so
+	@$(call ensure_relink,frida-core/src/frida.c,build/tmp-android-arm/frida-core/src/libfrida_core_la-frida.lo)
+	. build/frida-env-linux-arm.rc \
+		&& cd build/tmp-linux-arm/frida-core \
+		&& make -C src install \
+			RESOURCE_COMPILER="\"$(FRIDA)/releng/resource-compiler-linux-$(build_arch)\" --toolchain=gnu" \
+			HELPER32=../../../../build/tmp_stripped-linux-arm/frida-core/src/frida-helper!frida-helper-32 \
+			LOADER32=../../../../build/tmp_stripped-linux-arm/frida-core/lib/loader/.libs/libfrida-loader.so!frida-loader-32.so \
+			AGENT32=../../../../build/tmp_stripped-linux-arm/frida-core/lib/agent/.libs/libfrida-agent.so!frida-agent-32.so \
 		&& make install-data-am
 	@touch -c $@
 build/frida-android-i386/lib/pkgconfig/frida-core-1.0.pc: build/tmp_stripped-android-i386/frida-core/src/frida-helper build/tmp_stripped-android-i386/frida-core/lib/loader/.libs/libfrida-loader.so build/tmp_stripped-android-i386/frida-core/lib/agent/.libs/libfrida-agent.so

--- a/releng/config.site.in
+++ b/releng/config.site.in
@@ -23,6 +23,10 @@ case "$PACKAGE_TARNAME" in
 esac
 
 case $frida_host_platform_arch in
+  linux-arm)
+    host_alias="arm-linux-gnueabi"
+    cross_compiling=yes
+  ;;
   linux-i386)
     host_alias="i686-linux-gnu"
     cross_compiling=yes

--- a/releng/setup-env.sh
+++ b/releng/setup-env.sh
@@ -109,19 +109,31 @@ LDFLAGS=""
 
 case $host_platform in
   linux)
-    CPP="/usr/bin/cpp"
-    CC="/usr/bin/gcc -static-libgcc -static-libstdc++"
-    CXX="/usr/bin/g++ -static-libgcc -static-libstdc++"
-    LD="/usr/bin/ld"
+    case $host_arch in
+      i386)
+        host_arch_flags="-m32"
+        host_toolprefix="/usr/bin/"
+        ;;
+      x86_64)
+        host_arch_flags="-m64"
+        host_toolprefix="/usr/bin/"
+        ;;
+      arm)
+        host_arch_flags="-march=armv5t"
+        host_toolprefix="arm-linux-gnueabi-"
+        ;;
+    esac
+    CPP="${host_toolprefix}cpp"
+    CC="${host_toolprefix}gcc -static-libgcc -static-libstdc++"
+    CXX="${host_toolprefix}g++ -static-libgcc -static-libstdc++"
+    LD="${host_toolprefix}ld"
 
-    AR="/usr/bin/ar"
-    NM="/usr/bin/nm"
-    RANLIB="/usr/bin/ranlib"
-    STRIP="/usr/bin/strip"
+    AR="${host_toolprefix}ar"
+    NM="${host_toolprefix}nm"
+    RANLIB="${host_toolprefix}ranlib"
+    STRIP="${host_toolprefix}strip"
 
-    OBJDUMP="/usr/bin/objdump"
-
-    [ $host_arch == 'i386' ] && host_arch_flags="-m32" || host_arch_flags="-m64"
+    OBJDUMP="${host_toolprefix}objdump"
 
     CFLAGS="$host_arch_flags -ffunction-sections -fdata-sections"
     CXXFLAGS="-std=c++11"


### PR DESCRIPTION
Initial steps in porting frida to linux-arm. First add sdk support.