### PR TITLE
Add armhf target for hardfloat arm devices

### DIFF
--- a/Makefile.linux.mk
+++ b/Makefile.linux.mk
@@ -91,7 +91,7 @@ build/frida-%/lib/pkgconfig/capstone.pc: build/frida-env-%.rc build/capstone-sub
 			*-i386)   capstone_archs="x86"     ;; \
 			*-x86_64) capstone_archs="x86"     ;; \
 			*-arm)    capstone_archs="arm"     ;; \
-			*-armhf)    capstone_archs="arm"     ;; \
+			*-armhf)  capstone_archs="arm"     ;; \
 			*-arm64)  capstone_archs="aarch64" ;; \
 		esac \
 		&& make -C capstone \

--- a/Makefile.linux.mk
+++ b/Makefile.linux.mk
@@ -91,6 +91,7 @@ build/frida-%/lib/pkgconfig/capstone.pc: build/frida-env-%.rc build/capstone-sub
 			*-i386)   capstone_archs="x86"     ;; \
 			*-x86_64) capstone_archs="x86"     ;; \
 			*-arm)    capstone_archs="arm"     ;; \
+			*-armhf)    capstone_archs="arm"     ;; \
 			*-arm64)  capstone_archs="aarch64" ;; \
 		esac \
 		&& make -C capstone \
@@ -171,6 +172,17 @@ build/frida-linux-arm/lib/pkgconfig/frida-core-1.0.pc: build/tmp_stripped-linux-
 			HELPER32=../../../../build/tmp_stripped-linux-arm/frida-core/src/frida-helper!frida-helper-32 \
 			LOADER32=../../../../build/tmp_stripped-linux-arm/frida-core/lib/loader/.libs/libfrida-loader.so!frida-loader-32.so \
 			AGENT32=../../../../build/tmp_stripped-linux-arm/frida-core/lib/agent/.libs/libfrida-agent.so!frida-agent-32.so \
+		&& make install-data-am
+	@touch -c $@
+build/frida-linux-armhf/lib/pkgconfig/frida-core-1.0.pc: build/tmp_stripped-linux-armhf/frida-core/src/frida-helper build/tmp_stripped-linux-armhf/frida-core/lib/loader/.libs/libfrida-loader.so build/tmp_stripped-linux-armhf/frida-core/lib/agent/.libs/libfrida-agent.so
+	@$(call ensure_relink,frida-core/src/frida.c,build/tmp-android-armhf/frida-core/src/libfrida_core_la-frida.lo)
+	. build/frida-env-linux-armhf.rc \
+		&& cd build/tmp-linux-armhf/frida-core \
+		&& make -C src install \
+			RESOURCE_COMPILER="\"$(FRIDA)/releng/resource-compiler-linux-$(build_arch)\" --toolchain=gnu" \
+			HELPER32=../../../../build/tmp_stripped-linux-armhf/frida-core/src/frida-helper!frida-helper-32 \
+			LOADER32=../../../../build/tmp_stripped-linux-armhf/frida-core/lib/loader/.libs/libfrida-loader.so!frida-loader-32.so \
+			AGENT32=../../../../build/tmp_stripped-linux-armhf/frida-core/lib/agent/.libs/libfrida-agent.so!frida-agent-32.so \
 		&& make install-data-am
 	@touch -c $@
 build/frida-android-i386/lib/pkgconfig/frida-core-1.0.pc: build/tmp_stripped-android-i386/frida-core/src/frida-helper build/tmp_stripped-android-i386/frida-core/lib/loader/.libs/libfrida-loader.so build/tmp_stripped-android-i386/frida-core/lib/agent/.libs/libfrida-agent.so
@@ -308,6 +320,9 @@ server-64: build/frida_stripped-linux-x86_64/bin/frida-server ##@server Build fo
 server-arm: build/frida_stripped-linux-arm/bin/frida-server ##@server Build for arm
 	mkdir -p $(BINDIST)/bin
 	cp -f build/frida_stripped-linux-arm/bin/frida-server $(BINDIST)/bin/frida-server-linux-arm
+server-armhf: build/frida_stripped-linux-armhf/bin/frida-server ##@server Build for arm
+	mkdir -p $(BINDIST)/bin
+	cp -f build/frida_stripped-linux-armhf/bin/frida-server $(BINDIST)/bin/frida-server-linux-armhf
 server-android: build/frida_stripped-android-arm/bin/frida-server build/frida_stripped-android-arm64/bin/frida-server ##@server Build for Android
 	mkdir -p $(BINDIST)/bin
 	cp -f build/frida_stripped-android-arm/bin/frida-server $(BINDIST)/bin/frida-server-android

--- a/Makefile.sdk.mk
+++ b/Makefile.sdk.mk
@@ -291,12 +291,12 @@ endif
 ifeq ($(host_arch), arm)
 	v8_arch := arm
 	android_target_platform := 14
-	v8_arm_abifloat := -D armfloatabi=softfp
+	v8_abi_flags := -D armfloatabi=softfp
 endif
 ifeq ($(host_arch), armhf)
 	v8_arch := arm
 	android_target_platform := 14
-	v8_arm_abifloat := -D armfloatabi=hard
+	v8_abi_flags := -D armfloatabi=hard
 endif
 ifeq ($(host_arch), arm64)
 	v8_arch := arm64
@@ -322,7 +322,7 @@ endif
 ifeq ($(host_platform), ios)
 	v8_host_flags := -f make-mac -D mac_deployment_target=10.7 -D ios_deployment_target=7.0 -D clang=1
 endif
-v8_flags := -D host_os=$(build_platform) -D werror='' -D v8_use_external_startup_data=0 -D v8_enable_gdbjit=0 -D v8_enable_i18n_support=0 $(v8_host_flags) $(v8_arm_abifloat)
+v8_flags := -D host_os=$(build_platform) -D werror='' -D v8_use_external_startup_data=0 -D v8_enable_gdbjit=0 -D v8_enable_i18n_support=0 $(v8_host_flags) $(v8_abi_flags)
 
 v8_target := $(v8_flavor_prefix)$(v8_arch).release
 

--- a/Makefile.sdk.mk
+++ b/Makefile.sdk.mk
@@ -124,6 +124,10 @@ build/fs-tmp-%/zlib/Makefile: build/fs-env-%.rc build/.zlib-stamp
 				export PATH="$$(dirname $$NM):$$PATH"; \
 				export CHOST="arm-linux-gnueabi"; \
 				;; \
+			linux-armhf) \
+				export PATH="$$(dirname $$NM):$$PATH"; \
+				export CHOST="arm-linux-gnueabihf"; \
+				;; \
 			android-i386) \
 				export PATH="$$(dirname $$NM):$$PATH"; \
 				export CHOST="i686-linux-android"; \
@@ -287,6 +291,12 @@ endif
 ifeq ($(host_arch), arm)
 	v8_arch := arm
 	android_target_platform := 14
+	v8_arm_abifloat := -D armfloatabi=softfp
+endif
+ifeq ($(host_arch), armhf)
+	v8_arch := arm
+	android_target_platform := 14
+	v8_arm_abifloat := -D armfloatabi=hard
 endif
 ifeq ($(host_arch), arm64)
 	v8_arch := arm64
@@ -312,7 +322,7 @@ endif
 ifeq ($(host_platform), ios)
 	v8_host_flags := -f make-mac -D mac_deployment_target=10.7 -D ios_deployment_target=7.0 -D clang=1
 endif
-v8_flags := -D host_os=$(build_platform) -D werror='' -D v8_use_external_startup_data=0 -D v8_enable_gdbjit=0 -D v8_enable_i18n_support=0 $(v8_host_flags)
+v8_flags := -D host_os=$(build_platform) -D werror='' -D v8_use_external_startup_data=0 -D v8_enable_gdbjit=0 -D v8_enable_i18n_support=0 $(v8_host_flags) $(v8_arm_abifloat)
 
 v8_target := $(v8_flavor_prefix)$(v8_arch).release
 
@@ -370,10 +380,23 @@ ifeq ($(host_platform_arch), linux-arm)
 		CXXFLAGS="$$CXXFLAGS" \
 		CPPFLAGS="$$CPPFLAGs"
 else
+ifeq ($(host_platform_arch), linux-armhf)
+	v8_env_vars := \
+		CXX="$$CXX" \
+		CXX_host="g++ -m32" \
+		CXX_target="$$CXX" \
+		LINK="$$CXX" \
+		LINK_host="g++ -m32" \
+		CFLAGS="$$CFLAGS" \
+		LDFLAGS="$$LDFLAGS" \
+		CXXFLAGS="$$CXXFLAGS" \
+		CPPFLAGS="$$CPPFLAGs"
+else
 	v8_env_vars := \
 		CXX_host="$$CXX" \
 		CXX_target="$$CXX" \
 		LINK="$$CXX"
+endif
 endif
 endif
 endif

--- a/releng/config.site.in
+++ b/releng/config.site.in
@@ -26,6 +26,12 @@ case $frida_host_platform_arch in
   linux-arm)
     host_alias="arm-linux-gnueabi"
     cross_compiling=yes
+    enable_diet=yes
+  ;;
+  linux-armhf)
+    host_alias="arm-linux-gnueabihf"
+    cross_compiling=yes
+    enable_diet=yes
   ;;
   linux-i386)
     host_alias="i686-linux-gnu"

--- a/releng/setup-env.sh
+++ b/releng/setup-env.sh
@@ -119,6 +119,10 @@ case $host_platform in
         host_arch_flags="-march=armv5t"
         host_toolprefix="arm-linux-gnueabi-"
         ;;
+      armhf)
+        host_arch_flags="-march=armv6"
+        host_toolprefix="arm-linux-gnueabihf-"
+        ;;
     esac
     CPP="${host_toolprefix}cpp"
     CC="${host_toolprefix}gcc -static-libgcc -static-libstdc++"


### PR DESCRIPTION
Also set linux-arm and linux-armhf to use the Duktape runtime by default.