### PR TITLE
devkit.py tweaks

### DIFF
--- a/releng/devkit.py
+++ b/releng/devkit.py
@@ -88,7 +88,7 @@ def generate_header(package, frida_root, host, kit, umbrella_header_path):
             headers_seen.add(ref)
 
         frida_root_slashed = frida_root.replace("\\", "/")
-        header_files = [header_file for header_file in header_files if header_file.startswith(frida_root_slashed)]
+        header_files = [header_file for header_file in header_files if bool(re.match('^' + frida_root_slashed, header_file, re.I))]
     else:
         rc = env_rc(frida_root, host)
         header_dependencies = subprocess.check_output(

--- a/releng/devkit.py
+++ b/releng/devkit.py
@@ -344,10 +344,10 @@ def msvs_tool_path(host, tool):
     if host == "windows-x86_64":
         return r"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\{0}".format(tool)
     else:
-        return r"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64_x86\{0}".format(tool)
+        return r"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\{0}".format(tool)
 
 def msvs_runtime_path(host):
-    return r"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64"
+    return r"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin"
 
 def msvs_arch_config(host):
     if host == "windows-x86_64":
@@ -450,7 +450,7 @@ if __name__ == "__main__":
 
     kit = sys.argv[1]
     host = sys.argv[2]
-    outdir = sys.argv[3]
+    outdir = os.path.abspath(sys.argv[3])
 
     try:
         os.makedirs(outdir)

--- a/releng/devkit.py
+++ b/releng/devkit.py
@@ -76,17 +76,7 @@ def generate_header(package, frida_root, host, kit, umbrella_header_path):
         mapping_prefix = "#line "
         header_refs = [line[line.index("\"") + 1:line.rindex("\"")].replace("\\\\", "/") for line in lines if line.startswith(mapping_prefix)]
 
-        # c:/ => C:/
-        header_refs = [ref[0].upper() + ref[1:] for ref in header_refs]
-
-        header_files = []
-        headers_seen = set()
-        for ref in header_refs:
-            if ref in headers_seen:
-                continue
-            header_files.append(ref)
-            headers_seen.add(ref)
-
+        header_files = deduplicate(header_refs)
         frida_root_slashed = frida_root.replace("\\", "/")
         header_files = [header_file for header_file in header_files if bool(re.match('^' + frida_root_slashed, header_file, re.I))]
     else:
@@ -253,7 +243,7 @@ def generate_library_unix(package, frida_root, host, output_dir, library_filenam
     subprocess.check_output(
         ["(. \"{rc}\" && $AR rcs {library_path} {object_files} 2>/dev/null)".format(
             rc=rc,
-            library_path=os.path.abspath(os.path.join(output_dir, library_filename)),
+            library_path=os.path.join(output_dir, library_filename),
             object_files=" ".join([pipes.quote(object_name) for object_name in object_names]))],
         shell=True,
         cwd=combined_dir)


### PR DESCRIPTION
We were dropping json-version.h on the floor due to root path sensitivity.
Also adds relative output folder support (e.g. devkit.py frida-core windows outputfolder).