### PR TITLE
Add also arm to arm64 target (not for merge)

### DIFF
--- a/Makefile.mac.mk
+++ b/Makefile.mac.mk
@@ -104,7 +104,7 @@ build/frida-%/lib/pkgconfig/capstone.pc: build/frida-env-%.rc build/capstone-sub
 			*-i386)   capstone_archs="x86"     ;; \
 			*-x86_64) capstone_archs="x86"     ;; \
 			*-arm)    capstone_archs="arm"     ;; \
-			*-arm64)  capstone_archs="aarch64" ;; \
+			*-arm64)  capstone_archs="aarch64 arm" ;; \
 		esac \
 		&& make -C capstone \
 			PREFIX=$$frida_prefix \


### PR DESCRIPTION
- this is needed for arm64 server to deal with arm apps, and go disassemble their libSystem.B.dylib initializer

Not very happy with this change because i guess in this way also the agent will get an additional arm arch compiled in. Probably it's better to split the rule in agent / server cases.

related to https://github.com/frida/frida-core/pull/115