### PR TITLE
Use $(NPM) instead of npm for frida-gum

### DIFF
--- a/Makefile.linux.mk
+++ b/Makefile.linux.mk
@@ -108,7 +108,7 @@ gum-android: build/frida-android-arm/lib/pkgconfig/frida-gum-1.0.pc build/frida-
 define make-gum-rules
 build/.$1-gum-npm-stamp: build/$1-env-linux-$$(build_arch).rc
 	@$$(NPM) --version &>/dev/null || (echo -e "\033[31mOops. It appears Node.js is not installed.\nWe need it for processing JavaScript code at build-time.\nCheck PATH or set NODE to the absolute path of your Node.js binary.\033[0m"; exit 1;)
-	. build/$1-env-linux-$$(build_arch).rc && cd frida-gum/bindings/gumjs && npm install
+	. build/$1-env-linux-$$(build_arch).rc && cd frida-gum/bindings/gumjs && $(NPM) install
 	@touch $$@
 
 build/$1-%/lib/pkgconfig/frida-gum-1.0.pc: build/.frida-gum-submodule-stamp build/.$1-gum-npm-stamp build/$1-%/lib/pkgconfig/capstone.pc


### PR DESCRIPTION
With this, $(NPM) is used everywhere and a node installation in a none-standard location can be used during build.