### PR TITLE
Add server-android-arm build config

### DIFF
--- a/Makefile.linux.mk
+++ b/Makefile.linux.mk
@@ -569,7 +569,7 @@ check-tools-64-thin: build/tmp_thin-linux-x86_64/frida-tools-$(PYTHON_NAME)/.fri
 	capstone-update-submodule-stamp \
 	gum-32 gum-64 gum-32-thin gum-64-thin gum-android check-gum-32 check-gum-64 check-gum-32-thin check-gum-64-thin frida-gum-update-submodule-stamp \
 	core-32 core-64 core-32-thin core-64-thin core-android check-core-32 check-core-64 check-core-32-thin check-core-64-thin frida-core-update-submodule-stamp \
-        server-32 server-64 server-32-thin server-64-thin server-android server-android-arm server-qnx-arm server-qnx-armeabi \
+	server-32 server-64 server-32-thin server-64-thin server-android server-android-arm server-qnx-arm server-qnx-armeabi \
 	python-32 python-64 python-32-thin python-64-thin check-python-32 check-python-64 check-python-32-thin check-python-64-thin frida-python-update-submodule-stamp \
 	node-32 node-64 node-32-thin node-64-thin check-node-32 check-node-64 check-node-32-thin check-node-64-thin frida-node-update-submodule-stamp \
 	tools-32 tools-64 tools-32-thin tools-64-thin check-tools-32 check-tools-64 check-tools-32-thin check-tools-64-thin frida-tools-update-submodule-stamp \

--- a/Makefile.linux.mk
+++ b/Makefile.linux.mk
@@ -401,7 +401,8 @@ server-arm: build/frida-linux-arm/lib/pkgconfig/frida-core-1.0.pc ##@server Buil
 server-armhf: build/frida-linux-armhf/lib/pkgconfig/frida-core-1.0.pc ##@server Build for arm
 server-mips: build/frida-linux-mips/lib/pkgconfig/frida-core-1.0.pc ##@server Build for mips
 server-mipsel: build/frida-linux-mipsel/lib/pkgconfig/frida-core-1.0.pc ##@server Build for mipsel
-server-android: build/frida-android-x86/lib/pkgconfig/frida-core-1.0.pc build/frida-android-x86_64/lib/pkgconfig/frida-core-1.0.pc build/frida-android-arm/lib/pkgconfig/frida-core-1.0.pc build/frida-android-arm64/lib/pkgconfig/frida-core-1.0.pc ##@server Build for Android
+server-android: build/frida-android-x86/lib/pkgconfig/frida-core-1.0.pc build/frida-android-x86_64/lib/pkgconfig/frida-core-1.0.pc build/frida-android-arm/lib/pkgconfig/frida-core-1.0.pc build/frida-android-arm64/lib/pkgconfig/frida-core-1.0.pc ##@server Build for Android all supported architectures
+server-android-arm: build/frida-android-arm/lib/pkgconfig/frida-core-1.0.pc build/frida-android-arm64/lib/pkgconfig/frida-core-1.0.pc ##@server Build for Android arm and arm64 only
 server-qnx-arm: build/frida-qnx-arm/lib/pkgconfig/frida-core-1.0.pc ##@server Build for QNX-arm
 server-qnx-armeabi: build/frida-qnx-armeabi/lib/pkgconfig/frida-core-1.0.pc ##@server Build for QNX-armeabi
 
@@ -568,7 +569,7 @@ check-tools-64-thin: build/tmp_thin-linux-x86_64/frida-tools-$(PYTHON_NAME)/.fri
 	capstone-update-submodule-stamp \
 	gum-32 gum-64 gum-32-thin gum-64-thin gum-android check-gum-32 check-gum-64 check-gum-32-thin check-gum-64-thin frida-gum-update-submodule-stamp \
 	core-32 core-64 core-32-thin core-64-thin core-android check-core-32 check-core-64 check-core-32-thin check-core-64-thin frida-core-update-submodule-stamp \
-	server-32 server-64 server-32-thin server-64-thin server-android server-qnx-arm server-qnx-armeabi \
+        server-32 server-64 server-32-thin server-64-thin server-android server-android-arm server-qnx-arm server-qnx-armeabi \
 	python-32 python-64 python-32-thin python-64-thin check-python-32 check-python-64 check-python-32-thin check-python-64-thin frida-python-update-submodule-stamp \
 	node-32 node-64 node-32-thin node-64-thin check-node-32 check-node-64 check-node-32-thin check-node-64-thin frida-node-update-submodule-stamp \
 	tools-32 tools-64 tools-32-thin tools-64-thin check-tools-32 check-tools-64 check-tools-32-thin check-tools-64-thin frida-tools-update-submodule-stamp \

--- a/Makefile.macos.mk
+++ b/Makefile.macos.mk
@@ -391,7 +391,8 @@ server-macos: build/frida-macos-x86_64/lib/pkgconfig/frida-core-1.0.pc ##@server
 server-macos-thin: build/frida_thin-macos-x86_64/lib/pkgconfig/frida-core-1.0.pc ##@server Build for macOS without cross-arch support
 server-ios: build/frida-ios-arm/lib/pkgconfig/frida-core-1.0.pc build/frida-ios-arm64/lib/pkgconfig/frida-core-1.0.pc ##@server Build for iOS
 server-ios-thin: build/frida_thin-ios-arm64/lib/pkgconfig/frida-core-1.0.pc ##@server Build for iOS without cross-arch support
-server-android: build/frida-android-x86/lib/pkgconfig/frida-core-1.0.pc build/frida-android-x86_64/lib/pkgconfig/frida-core-1.0.pc build/frida-android-arm/lib/pkgconfig/frida-core-1.0.pc build/frida-android-arm64/lib/pkgconfig/frida-core-1.0.pc ##@server Build for Android
+server-android: build/frida-android-x86/lib/pkgconfig/frida-core-1.0.pc build/frida-android-x86_64/lib/pkgconfig/frida-core-1.0.pc build/frida-android-arm/lib/pkgconfig/frida-core-1.0.pc build/frida-android-arm64/lib/pkgconfig/frida-core-1.0.pc ##@server Build for Android all supported architectures
+server-android-arm: build/frida-android-arm/lib/pkgconfig/frida-core-1.0.pc build/frida-android-arm64/lib/pkgconfig/frida-core-1.0.pc ##@server Build for Android arm and arm64 only
 
 gadget-macos: build/frida-macos-universal/lib/FridaGadget.dylib ##@gadget Build for macOS
 gadget-macos-thin: build/frida_thin-macos-x86_64/lib/FridaGadget.dylib ##@gadget Build for macOS without cross-arch support
@@ -542,7 +543,7 @@ check-tools-macos-thin: tools-macos-thin ##@tools Test CLI tools for macOS witho
 	capstone-update-submodule-stamp \
 	gum-macos gum-macos-thin gum-ios gum-ios-thin gum-android check-gum-macos check-gum-macos-thin frida-gum-update-submodule-stamp \
 	core-macos core-macos-thin core-ios core-ios-thin core-android check-core-macos check-core-macos-thin check-core-android-arm64 frida-core-update-submodule-stamp \
-	server-macos server-macos-thin server-ios server-ios-thin server-android \
+	server-macos server-macos-thin server-ios server-ios-thin server-android server-android-arm
 	gadget-macos gadget-macos-thin gadget-ios gadget-ios-thin gadget-android \
 	python-macos python-macos-thin check-python-macos check-python-macos-thin frida-python-update-submodule-stamp \
 	node-macos node-macos-thin check-node-macos check-node-macos-thin frida-node-update-submodule-stamp \

--- a/Makefile.macos.mk
+++ b/Makefile.macos.mk
@@ -543,7 +543,7 @@ check-tools-macos-thin: tools-macos-thin ##@tools Test CLI tools for macOS witho
 	capstone-update-submodule-stamp \
 	gum-macos gum-macos-thin gum-ios gum-ios-thin gum-android check-gum-macos check-gum-macos-thin frida-gum-update-submodule-stamp \
 	core-macos core-macos-thin core-ios core-ios-thin core-android check-core-macos check-core-macos-thin check-core-android-arm64 frida-core-update-submodule-stamp \
-	server-macos server-macos-thin server-ios server-ios-thin server-android server-android-arm
+	server-macos server-macos-thin server-ios server-ios-thin server-android server-android-arm \
 	gadget-macos gadget-macos-thin gadget-ios gadget-ios-thin gadget-android \
 	python-macos python-macos-thin check-python-macos check-python-macos-thin frida-python-update-submodule-stamp \
 	node-macos node-macos-thin check-node-macos check-node-macos-thin frida-node-update-submodule-stamp \


### PR DESCRIPTION
Nice build system, works really well and quickly.

It gets a bit old though building x86 pieces for Android every time, so this new build configuration lets you build only the arm pieces.

Open to a new name since 'arm' might imply only 'arm32', but I don't know of any generic name for all ARM architectures. 