### PR TITLE
Fix to address linking issue described in https://github.com/frida/frida/issues/636

### DIFF
--- a/releng/setup-env.sh
+++ b/releng/setup-env.sh
@@ -466,7 +466,7 @@ case $host_platform in
     OBJCOPY="${android_toolroot}/bin/${host_toolprefix}objcopy"
     OBJDUMP="${android_toolroot}/bin/${host_toolprefix}objdump"
 
-    CFLAGS="$host_arch_flags -DANDROID -fPIC -ffunction-sections -fdata-sections"
+    CFLAGS="$host_arch_flags -DANDROID -ffunction-sections -fdata-sections"
     LDFLAGS="$host_arch_flags $host_ldflags -Wl,--gc-sections -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now"
 
     elf_cleaner=${FRIDA_ROOT}/releng/frida-elf-cleaner-${build_platform_arch}

--- a/releng/setup-env.sh
+++ b/releng/setup-env.sh
@@ -466,7 +466,7 @@ case $host_platform in
     OBJCOPY="${android_toolroot}/bin/${host_toolprefix}objcopy"
     OBJDUMP="${android_toolroot}/bin/${host_toolprefix}objdump"
 
-    CFLAGS="$host_arch_flags -DANDROID -fPIE -ffunction-sections -fdata-sections"
+    CFLAGS="$host_arch_flags -DANDROID -fPIC -ffunction-sections -fdata-sections"
     LDFLAGS="$host_arch_flags $host_ldflags -Wl,--gc-sections -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now"
 
     elf_cleaner=${FRIDA_ROOT}/releng/frida-elf-cleaner-${build_platform_arch}
@@ -489,7 +489,7 @@ case $host_platform in
     if [ -n "$base_toolchain_args" ]; then
       base_toolchain_args="$base_toolchain_args, "
     fi
-    base_compiler_args="$base_toolchain_args'-DANDROID', '-fPIE', '-ffunction-sections', '-fdata-sections'"
+    base_compiler_args="$base_toolchain_args'-DANDROID', '-fPIC', '-ffunction-sections', '-fdata-sections'"
     base_linker_args="$base_toolchain_args$(flags_to_args "$host_ldflags"), '-Wl,--gc-sections', '-Wl,-z,noexecstack', '-Wl,-z,relro', '-Wl,-z,now'"
 
     meson_c="$meson_cc_wrapper"


### PR DESCRIPTION
Updating the compiler flags to build with PIC-enabled.  Previously, the flag being used for this was -fPIE which is used for executables.  This is now changed to -fPIC which is the flag that should be used for shared libraries.

The way I tested this was by creating my own build of the SDK for android-related ABIS (arm, arm64, x86 and x86_64).  I produced this build using the following commands.

make -f Makefile.sdk.mk FRIDA_HOST=android-arm64
make -f Makefile.sdk.mk FRIDA_HOST=android-arm
make -f Makefile.sdk.mk FRIDA_HOST=android-x86_64
make -f Makefile.sdk.mk FRIDA_HOST=android-x86

I then created my own build of frida-gum using the following command.

make gum-android

I linked this new build against my own project and ran through my own tests.  Everything worked correctly on my end.  If there are any other tests you would like me to run, please feel free to suggest.

As mentioned in the title, this is to address https://github.com/frida/frida/issues/636
