### PR TITLE
set LC_ALL to "en_US" instead of "en_US.UTF-8"

### DIFF
--- a/releng/setup-env.sh
+++ b/releng/setup-env.sh
@@ -795,7 +795,7 @@ fi
   echo "export ACLOCAL=\"$ACLOCAL\""
   echo "export CONFIG_SITE=\"$CONFIG_SITE\""
   echo "unset LANG LC_ALL LC_COLLATE LC_CTYPE LC_MESSAGES LC_NUMERIC LC_TIME"
-  echo "export LC_ALL=en_US.UTF-8"
+  echo "export LC_ALL=en_US"
 ) > $env_rc
 
 case $host_platform in


### PR DESCRIPTION
the forked vala compiler segfaults if LC_ALL is set to "en_US.UTF-8" but works
if the variable is set to "en_US"

this seems to be a problem from glibc 2.28 onwards which is used e.g. in Ubuntu 18.10

fixes #733