### PR TITLE
Disable openssl tests to speed up SDK build

### DIFF
--- a/Makefile.sdk.mk
+++ b/Makefile.sdk.mk
@@ -406,6 +406,7 @@ build/fs-%/lib/pkgconfig/openssl.pc: build/fs-env-%.rc build/fs-tmp-%/openssl/Co
 			--prefix=$$frida_prefix \
 			--openssldir=/etc/ssl \
 			no-engine \
+			no-tests \
 			no-comp \
 			no-ssl3 \
 			no-zlib \


### PR DESCRIPTION
OpenSSL tests are built by default and take a significant amount of build time. Since they are not ran anyway, why not disable them completely?