### PR TITLE
Two minor spelling errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -384,7 +384,7 @@ ret = thread_create (task, &instance->thread);
 
 ### Rule
 
-When declaring pointers, put a space before and afer `*`.
+When declaring pointers, put a space before and after `*`.
 
 #### Wrong
 
@@ -1329,7 +1329,7 @@ Lines should not exceed 80 characters.
 
 ### Rule
 
-When definining a function implementation each argument must go on
+When defining a function implementation each argument must go on
 its own line, vertically aligned (not for the prototype).
 
 #### Wrong


### PR DESCRIPTION
Hi oleavr,

Two very minor spelling mistakes, one that caught my eye, the other caught by spell-checker.

An excellent document, clearly specifying the coding standard.  I had to do a double-take on some examples that seemed eerily familiar, until I noticed they *were* taken from my recent code, and that the entire document was newly written two weeks ago! :-)