### PR TITLE
Update README.md macOS and iOS section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ for code signing". You can use the name `frida-cert` instead of `gdb-cert`
 if you'd like.
 
 Next export the name of the created certificate to the environment variables
-`MACOS_CERTID` and `IOS_CERTID`, and run `make`:
+`MAC_CERTID` and `IOS_CERTID`, and run `make`:
 
-    export MACOS_CERTID=frida-cert
+    export MAC_CERTID=frida-cert
     export IOS_CERTID=frida-cert
     make
 


### PR DESCRIPTION
when running `make core-macos-thin` I would receive a warning that `MAC_CERTID` was not set. Updating my environment variable to `MAC_CERTID` fixed that warning.