### PR TITLE
Add `glib-mkenums` to Windows toolchain

### DIFF
--- a/releng/build-deps-windows.py
+++ b/releng/build-deps-windows.py
@@ -92,7 +92,7 @@ def check_environment():
         print("ERROR: {}".format(e), file=sys.stderr)
         sys.exit(1)
 
-    for tool in ["git", "py"]:
+    for tool in ["7z", "git", "py"]:
         if shutil.which(tool) is None:
             print("ERROR: {} not found".format(tool), file=sys.stderr)
             sys.exit(1)
@@ -519,7 +519,7 @@ def package():
     for root, dirs, files in os.walk(get_prefix_path('x86', 'Release', 'static')):
         relpath = root[prefixes_skip_len:]
         included_files = map(lambda name: os.path.join(relpath, name),
-            filter(lambda filename: file_is_vala_toolchain_related(relpath, filename) or filename == "pkg-config.exe", files))
+            filter(lambda filename: file_is_vala_toolchain_related(relpath, filename) or filename in ("pkg-config.exe", "glib-mkenums", "glib-genmarshal"), files))
         toolchain_files.extend(included_files)
 
     toolchain_mixin_files = []

--- a/releng/build-deps-windows.py
+++ b/releng/build-deps-windows.py
@@ -519,7 +519,7 @@ def package():
     for root, dirs, files in os.walk(get_prefix_path('x86', 'Release', 'static')):
         relpath = root[prefixes_skip_len:]
         included_files = map(lambda name: os.path.join(relpath, name),
-            filter(lambda filename: file_is_vala_toolchain_related(relpath, filename) or filename in ("pkg-config.exe", "glib-mkenums", "glib-genmarshal"), files))
+            filter(lambda filename: file_is_vala_toolchain_related(relpath, filename) or filename in ("pkg-config.exe", "glib-genmarshal", "glib-mkenums"), files))
         toolchain_files.extend(included_files)
 
     toolchain_mixin_files = []

--- a/releng/frida.props
+++ b/releng/frida.props
@@ -4,6 +4,8 @@
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
     <OutDir>$(SolutionDir)build\frida-windows\$(PlatformName)-$(Configuration)\bin\</OutDir>
     <IntDir>$(SolutionDir)build\tmp-windows\$(PlatformName)-$(Configuration)\$(ProjectName)\</IntDir>
+    <GLibMkenums>py -3 $(SolutionDir)build\toolchain-windows\bin\glib-mkenums</GLibMkenums>
+    <GLibGenmarshal>py -3 $(SolutionDir)build\toolchain-windows\bin\glib-genmarshal</GLibGenmarshal>
     <ValaCompiler>$(SolutionDir)build\toolchain-windows\bin\valac-0.50.exe</ValaCompiler>
     <ValaFlags>--target-glib=2.66 --vapidir="$(SolutionDir)frida-core\vapi" --vapidir="$(SolutionDir)frida-gum\vapi" --vapidir="$(SolutionDir)build\sdk-windows\$(Platform)-$(Configuration)\share\vala\vapi"</ValaFlags>
     <XPDeprecationWarning>false</XPDeprecationWarning>

--- a/releng/frida.props
+++ b/releng/frida.props
@@ -4,8 +4,8 @@
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
     <OutDir>$(SolutionDir)build\frida-windows\$(PlatformName)-$(Configuration)\bin\</OutDir>
     <IntDir>$(SolutionDir)build\tmp-windows\$(PlatformName)-$(Configuration)\$(ProjectName)\</IntDir>
-    <GLibMkenums>py -3 $(SolutionDir)build\toolchain-windows\bin\glib-mkenums</GLibMkenums>
     <GLibGenmarshal>py -3 $(SolutionDir)build\toolchain-windows\bin\glib-genmarshal</GLibGenmarshal>
+    <GLibMkenums>py -3 $(SolutionDir)build\toolchain-windows\bin\glib-mkenums</GLibMkenums>
     <ValaCompiler>$(SolutionDir)build\toolchain-windows\bin\valac-0.50.exe</ValaCompiler>
     <ValaFlags>--target-glib=2.66 --vapidir="$(SolutionDir)frida-core\vapi" --vapidir="$(SolutionDir)frida-gum\vapi" --vapidir="$(SolutionDir)build\sdk-windows\$(Platform)-$(Configuration)\share\vala\vapi"</ValaFlags>
     <XPDeprecationWarning>false</XPDeprecationWarning>


### PR DESCRIPTION
- As well, fix a bug where 7z is not found on the users system and
  it results in a cryptic Windows DirectoryNotFound error
- Add `GlibMkenums` variable for all VS subprojects