### PR TITLE
Make armhf build again

### DIFF
--- a/Makefile.sdk.mk
+++ b/Makefile.sdk.mk
@@ -38,7 +38,7 @@ else
 endif
 host_platform_arch := $(host_platform)-$(host_arch)
 
-enable_v8 := $(shell echo $(host_platform_arch) | egrep -q "^(linux-arm|linux-armbe8|linux-mips|linux-mipsel|linux-mips64|linux-mips64el|qnx-.+)$$" && echo 0 || echo 1)
+enable_v8 := $(shell echo $(host_platform_arch) | egrep -q "^(linux-arm|linux-armhf|linux-armbe8|linux-mips|linux-mipsel|linux-mips64|linux-mips64el|qnx-.+)$$" && echo 0 || echo 1)
 
 
 ifeq ($(host_platform), macos)
@@ -378,6 +378,9 @@ ifeq ($(host_arch), x86_64)
 	openssl_arch_args := linux-x86_64 enable-ec_nistp_64_gcc_128
 endif
 ifeq ($(host_arch), arm)
+	openssl_arch_args := linux-armv4
+endif
+ifeq ($(host_arch), armhf)
 	openssl_arch_args := linux-armv4
 endif
 ifeq ($(host_arch), armbe8)

--- a/releng/setup-env.sh
+++ b/releng/setup-env.sh
@@ -216,10 +216,10 @@ case $host_platform in
         meson_host_cpu="armv6t"
         ;;
       armhf)
-        host_arch_flags="-march=armv6"
+        host_arch_flags="-march=armv7-a"
         host_toolprefix="arm-linux-gnueabihf-"
 
-        meson_host_cpu="armv6hf"
+        meson_host_cpu="armv7a"
         ;;
       arm64)
         host_arch_flags="-march=armv8-a"


### PR DESCRIPTION
The armhf build targets where broken. 

After this commit is it possible to install the armhf toolchain and build the arm target again.
e.g.

make -f Makefile.sdk.mk  FRIDA_HOST=linux-armhf
make gum-linux-armhf
make core-linux-armhf 
Produces a working frida-server

Fixes:
* Do not build v8 when targeting the armhf target
* Change armv6hf to armv7 (less of a hassle with respect to hard float) and thumb code generation (it just works[tm])
* Copy the openssh build option from the arm target

Still when compiling from scratch the frida-server will not respond. To make frida-server work I first need to build the linux  frida-linux-x86_64 target. ( I suspect from files / javascript is generated that are reused for the arm build) not quite sure what is going on.

