### PR TITLE
Add support for shared GLib configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /releng/__pycache__/
 /releng/modules/frida-gadget-ios/*.dylib
 /releng/modules/frida-gadget-ios/node_modules
+/g-ir-cpp-*.c

--- a/Makefile.linux.mk
+++ b/Makefile.linux.mk
@@ -57,10 +57,12 @@ clean: clean-submodules
 	rm -f build/frida-version.h
 	rm -rf build/frida-*-*
 	rm -rf build/frida_thin-*-*
+	rm -rf build/frida_gir-*-*
 	rm -rf build/fs-*-*
 	rm -rf build/ft-*-*
 	rm -rf build/tmp-*-*
 	rm -rf build/tmp_thin-*-*
+	rm -rf build/tmp_gir-*-*
 	rm -rf build/fs-tmp-*-*
 	rm -rf build/ft-tmp-*-*
 
@@ -76,6 +78,7 @@ gum-linux-x86: build/frida-linux-x86/lib/pkgconfig/frida-gum-1.0.pc ##@gum Build
 gum-linux-x86_64: build/frida-linux-x86_64/lib/pkgconfig/frida-gum-1.0.pc ##@gum Build for Linux/x86-64
 gum-linux-x86-thin: build/frida_thin-linux-x86/lib/pkgconfig/frida-gum-1.0.pc ##@gum Build for Linux/x86 without cross-arch support
 gum-linux-x86_64-thin: build/frida_thin-linux-x86_64/lib/pkgconfig/frida-gum-1.0.pc ##@gum Build for Linux/x86-64 without cross-arch support
+gum-linux-x86_64-gir: build/frida_gir-linux-x86_64/lib/pkgconfig/frida-gum-1.0.pc ##@gum Build for Linux/x86-64 with shared GLib and GIR
 gum-linux-arm: build/frida_thin-linux-arm/lib/pkgconfig/frida-gum-1.0.pc ##@gum Build for Linux/arm
 gum-linux-armbe8: build/frida_thin-linux-armbe8/lib/pkgconfig/frida-gum-1.0.pc ##@gum Build for Linux/armbe8
 gum-linux-armhf: build/frida_thin-linux-armhf/lib/pkgconfig/frida-gum-1.0.pc ##@gum Build for Linux/armhf
@@ -114,6 +117,7 @@ build/$1-%/lib/pkgconfig/frida-gum-1.0.pc: build/$1-env-%.rc build/.frida-gum-su
 endef
 $(eval $(call make-gum-rules,frida,tmp))
 $(eval $(call make-gum-rules,frida_thin,tmp_thin))
+$(eval $(call make-gum-rules,frida_gir,tmp_gir))
 
 check-gum-linux-x86: gum-linux-x86 ##@gum Run tests for Linux/x86
 	build/tmp-linux-x86/frida-gum/tests/gum-tests $(test_args)
@@ -457,7 +461,7 @@ check-tools-linux-arm64: build/tmp_thin-linux-arm64/frida-tools-$(PYTHON_NAME)/.
 	help \
 	distclean clean clean-submodules git-submodules git-submodule-stamps \
 	gum-linux-x86 gum-linux-x86_64 \
-		gum-linux-x86-thin gum-linux-x86_64-thin \
+		gum-linux-x86-thin gum-linux-x86_64-thin gum-linux-x86_64-gir \
 		gum-linux-arm gum-linux-armbe8 gum-linux-armhf gum-linux-arm64 \
 		gum-linux-mips gum-linux-mipsel \
 		gum-linux-mips64 gum-linux-mips64el \

--- a/releng/frida.mk
+++ b/releng/frida.mk
@@ -32,6 +32,21 @@ build/frida_thin-env-%.rc: releng/setup-env.sh releng/config.site.in build/frida
 	[ ! -d toolchain-$* ] && ln -s frida_thin-toolchain-$* toolchain-$*; \
 	true
 
+build/frida_gir-env-%.rc: releng/setup-env.sh releng/config.site.in build/frida-version.h
+	@FRIDA_HOST=$* \
+		FRIDA_ACOPTFLAGS="$(FRIDA_ACOPTFLAGS_COMMON)" \
+		FRIDA_ACDBGFLAGS="$(FRIDA_ACDBGFLAGS_COMMON)" \
+		FRIDA_ASAN=$(FRIDA_ASAN) \
+		FRIDA_ENV_NAME=frida_gir \
+		./releng/setup-env.sh
+	@cd $(FRIDA)/build/; \
+	[ ! -e frida-env-$*.rc ] && ln -s frida_gir-env-$*.rc frida-env-$*.rc; \
+	[ ! -e frida-meson-env-$*.rc ] && ln -s frida_gir-meson-env-$*.rc frida-meson-env-$*.rc; \
+	[ ! -d frida-$* ] && ln -s frida_gir-$* frida-$*; \
+	[ ! -d sdk-$* ] && ln -s frida_gir-sdk-$* sdk-$*; \
+	[ ! -d toolchain-$* ] && ln -s frida_gir-toolchain-$* toolchain-$*; \
+	true
+
 build/frida-version.h: releng/generate-version-header.py .git/refs/heads/master
 	@$(PYTHON3) releng/generate-version-header.py > $@.tmp
 	@mv $@.tmp $@

--- a/releng/setup-env.sh
+++ b/releng/setup-env.sh
@@ -897,16 +897,20 @@ chmod 755 "$strip_wrapper"
 PKG_CONFIG=$FRIDA_BUILD/${FRIDA_ENV_NAME:-frida}-${host_os_arch}-pkg-config
 
 pkg_config="$FRIDA_TOOLROOT/bin/pkg-config"
-pkg_config_flags=""
+pkg_config_flags="--static"
 pkg_config_path="$FRIDA_PREFIX_LIB/pkgconfig"
+if [ "$FRIDA_ENV_NAME" == 'frida_gir' ]; then
+	pkg_config_path="/usr/lib/pkgconfig"
+	pkg_config_flags=""
+fi
 if [ "$FRIDA_ENV_SDK" != 'none' ]; then
-  pkg_config_flags=" --define-variable=frida_sdk_prefix=$FRIDA_SDKROOT"
+  pkg_config_flags=" $pkg_config_flags --define-variable=frida_sdk_prefix=$FRIDA_SDKROOT"
   pkg_config_path="$pkg_config_path:$FRIDA_SDKROOT/lib/pkgconfig"
 fi
 (
   echo "#!/bin/sh"
   echo "export PKG_CONFIG_PATH=\"$pkg_config_path\""
-  echo "exec \"$pkg_config\"$pkg_config_flags --static \"\$@\""
+  echo "exec \"$pkg_config\"$pkg_config_flags \"\$@\""
 ) > "$PKG_CONFIG"
 chmod 755 "$PKG_CONFIG"
 
@@ -922,7 +926,7 @@ fi
 (
   echo "export PATH=\"${env_path_sdk}${FRIDA_TOOLROOT}/bin:\$PATH\""
   echo "export PKG_CONFIG=\"$PKG_CONFIG\""
-  echo "export PKG_CONFIG_PATH=\"\""
+  echo "export PKG_CONFIG_PATH=\"$pkg_config_path\""
   echo "export VALAC=\"$VALAC\""
   echo "export CPP=\"$CPP\""
   echo "export CPPFLAGS=\"$CPPFLAGS\""
@@ -984,7 +988,7 @@ sed \
 (
   echo "export PATH=\"${env_path_sdk}${FRIDA_TOOLROOT}/bin:\$PATH\""
   echo "export PKG_CONFIG=\"$PKG_CONFIG\""
-  echo "export PKG_CONFIG_PATH=\"\""
+  echo "export PKG_CONFIG_PATH=\"$pkg_config_path\""
   echo "export VALAC=\"$VALAC\""
   echo "export CPPFLAGS=\"$CPPFLAGS\""
   echo "export CC=\"$CC\""


### PR DESCRIPTION
- Also support .gir generation in frida-gum

This is just a first pass. It works! However, I'd like to discuss how this should be handled. I was thinking that instead there should be another build target `gum-linux-x86_64-gir` and the like where the only real product of the build that should be used is the produced `.gir`. We can then add more of these targets once the GLib shared changes are ported to `frida-core`.