### PR TITLE
Fix building with FRIDA_ASAN=yes

### DIFF
--- a/releng/deps.mk
+++ b/releng/deps.mk
@@ -53,6 +53,7 @@ autoconf_hash = 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
 autoconf_recipe = autotools
 autoconf_patches = \
 	autoconf-uclibc.patch \
+	autoconf-doc-fix-texinfo-macro-usage.patch \
 	$(NULL)
 autoconf_options = \
 	$(NULL)

--- a/releng/patches/autoconf-doc-fix-texinfo-macro-usage.patch
+++ b/releng/patches/autoconf-doc-fix-texinfo-macro-usage.patch
@@ -1,0 +1,109 @@
+From a357718b081f1678748ead5d7cb67c766c930441 Mon Sep 17 00:00:00 2001
+From: Patrice Dumas <pertusus@free.fr>
+Date: Wed, 18 Jul 2012 13:41:45 -0600
+Subject: [PATCH] doc: fix texinfo macro usage
+
+The texinfo manual recommends avoiding the use of a trailing @c in
+any macro designed to be used inline (as is the case with our ovar
+and dvar macros).  Furthermore, passing '@\n' in the middle of a
+macro call is much different than passing '@\n' between arguments
+of a @defmac for line continuation.
+
+* doc/autoconf.texi (ovar, dvar): Don't end macro with @c, since
+these macros are designed to be embedded in one-line usage.
+(Fortran Compiler): Don't split @dvar.
+* THANKS: Update.
+Reported by Stefano Lattarini.
+
+Signed-off-by: Eric Blake <eblake@redhat.com>
+Copyright-paperwork-exempt: Yes
+---
+ THANKS            |  1 +
+ doc/autoconf.texi | 24 ++++++++++++------------
+ 2 files changed, 13 insertions(+), 12 deletions(-)
+
+diff --git a/THANKS b/THANKS
+index 25734d59..8682c87e 100644
+--- a/THANKS
++++ b/THANKS
+@@ -316,6 +316,7 @@ Olly Betts                  olly@survex.com
+ Ossama Othman               ossama@debian.org
+ Pallav Gupta                pallavgupta@gmail.com
+ Paolo Bonzini               bonzini@gnu.org
++Patrice Dumas               pertusus@free.fr
+ Patrick Tullmann            tullmann@cs.utah.edu
+ Patrick Welche              prlw1@newn.cam.ac.uk
+ Paul Berrevoets             paul@swi.com
+diff --git a/doc/autoconf.texi b/doc/autoconf.texi
+index 78a2c67f..506d9667 100644
+--- a/doc/autoconf.texi
++++ b/doc/autoconf.texi
+@@ -15,7 +15,7 @@
+ @c The ARG is an optional argument.  To be used for macro arguments in
+ @c their documentation (@defmac).
+ @macro ovar{varname}
+-@r{[}@var{\varname\}@r{]}@c
++@r{[}@var{\varname\}@r{]}
+ @end macro
+ 
+ @c @dvar(ARG, DEFAULT)
+@@ -23,7 +23,7 @@
+ @c The ARG is an optional argument, defaulting to DEFAULT.  To be used
+ @c for macro arguments in their documentation (@defmac).
+ @macro dvar{varname, default}
+-@r{[}@var{\varname\} = @samp{\default\}@r{]}@c
++@r{[}@var{\varname\} = @samp{\default\}@r{]}
+ @end macro
+ 
+ @c Handling the indexes with Texinfo yields several different problems.
+@@ -8014,10 +8014,10 @@ variables, respectively.  The computed linker flags are cached in
+ @code{ac_cv_f77_libs} or @code{ac_cv_fc_libs}, respectively.
+ @end defmac
+ 
+-@defmac AC_F77_DUMMY_MAIN (@ovar{action-if-found}, @dvar{action-if-not-found, @
+-  AC_MSG_FAILURE})
+-@defmacx AC_FC_DUMMY_MAIN (@ovar{action-if-found}, @dvar{action-if-not-found, @
+-  AC_MSG_FAILURE})
++@defmac AC_F77_DUMMY_MAIN (@ovar{action-if-found}, @
++  @dvar{action-if-not-found, AC_MSG_FAILURE})
++@defmacx AC_FC_DUMMY_MAIN (@ovar{action-if-found}, @
++  @dvar{action-if-not-found, AC_MSG_FAILURE})
+ @acindex{F77_DUMMY_MAIN}
+ @cvindex F77_DUMMY_MAIN
+ @acindex{FC_DUMMY_MAIN}
+@@ -8268,8 +8268,8 @@ results in @code{ac_cv_fc_srcext_@var{ext}} and
+ @code{ac_cv_fc_pp_srcext_@var{ext}} variables, respectively.
+ @end defmac
+ 
+-@defmac AC_FC_PP_DEFINE (@ovar{action-if-success}, @dvar{action-if-failure, @
+-  AC_MSG_FAILURE})
++@defmac AC_FC_PP_DEFINE (@ovar{action-if-success}, @
++  @dvar{action-if-failure, AC_MSG_FAILURE})
+ @acindex{FC_PP_DEFINE}
+ @caindex fc_pp_define
+ 
+@@ -8287,8 +8287,8 @@ The result of this test is cached in the @code{ac_cv_fc_pp_define}
+ variable.
+ @end defmac
+ 
+-@defmac AC_FC_FREEFORM (@ovar{action-if-success}, @dvar{action-if-failure, @
+-  AC_MSG_FAILURE})
++@defmac AC_FC_FREEFORM (@ovar{action-if-success}, @
++  @dvar{action-if-failure, AC_MSG_FAILURE})
+ @acindex{FC_FREEFORM}
+ @caindex fc_freeform
+ 
+@@ -8314,8 +8314,8 @@ The result of this test, or @samp{none} or @samp{unknown}, is cached in
+ the @code{ac_cv_fc_freeform} variable.
+ @end defmac
+ 
+-@defmac AC_FC_FIXEDFORM (@ovar{action-if-success}, @dvar{action-if-failure, @
+-  AC_MSG_FAILURE})
++@defmac AC_FC_FIXEDFORM (@ovar{action-if-success}, @
++  @dvar{action-if-failure, AC_MSG_FAILURE})
+ @acindex{FC_FIXEDFORM}
+ @caindex fc_fixedform
+ 
+-- 
+2.25.1
+

--- a/releng/setup-env.sh
+++ b/releng/setup-env.sh
@@ -835,6 +835,7 @@ meson_cpp_link_args="$meson_cpp_link_args, $meson_legacy_libpaths"
 
 if [ $enable_asan = yes ]; then
   sanitizer_flag="-fsanitize=address"
+  meson_sanitizer_arg=$(flags_to_args "$sanitizer_flag")
 
   CC="$CC $sanitizer_flag"
   CXX="$CXX $sanitizer_flag"
@@ -845,6 +846,8 @@ if [ $enable_asan = yes ]; then
     OBJCXX="$OBJCXX $sanitizer_flag"
   fi
   LD="$LD $sanitizer_flag"
+  meson_c_args="$meson_c_args, $meson_sanitizer_arg"
+  meson_cpp_args="$meson_cpp_args, $meson_sanitizer_arg"
 fi
 
 CFLAGS="-fPIC $CFLAGS"


### PR DESCRIPTION
I had to make these two fixes in order to build toolchain, SDK and tests with `FRIDA_ASAN=yes` on my Ubuntu 20.04:

1) Build CFLAGS had `-fsanitize=address`, but host CFLAGS didn't. This messed up `HAVE_FRIDA_GLIB` detection.
2) autoconf couldn't be built due to a problem in `doc/autoconf.texi`.