### PR TITLE
Use system pkg-config for GLib shared configuration

### DIFF
--- a/releng/setup-env.sh
+++ b/releng/setup-env.sh
@@ -898,7 +898,7 @@ pkg_config="$FRIDA_TOOLROOT/bin/pkg-config"
 pkg_config_flags="--static"
 pkg_config_path="$FRIDA_PREFIX_LIB/pkgconfig"
 if [ "$FRIDA_ENV_NAME" == 'frida_gir' ]; then
-	pkg_config_path="/usr/lib/pkgconfig"
+	pkg_config_path="$(pkg-config --variable pc_path pkg-config):$pkg_config_path"
 	pkg_config_flags=""
 fi
 if [ "$FRIDA_ENV_SDK" != 'none' ]; then


### PR DESCRIPTION
On Fedora, for example, the path for x86_64 pkg-config is in `/usr/lib64/pkgconfig`

Additionally, when other targets such as frida-core look for pkgconfig scripts such as frida-gum, they were previously not included in the search path. By including their build path, this issue is fixed.