### PR TITLE
Improve readme with compiling tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ few packages:
 
     pip3 install colorama prompt-toolkit pygments
 
+_You might get errors from the `read-elf` if your OS is not
+in English, since some of the tooling here uses regex with English words,
+changing the language to `en_US` helps with it._
 ### Linux
 
     make


### PR DESCRIPTION
# Context
I was trying to compile frida in my raspberry pi 4, most of the things were flawless, however, at some point I've bumped into:
```bash
[1/79] Generating lib/agent/frida-agent-modulated with a custom command
FAILED: lib/agent/libfrida-agent-modulated.so
/root/frida/frida-core/tools/modulate.py lib/agent/libfrida-agent.so --move constructor frida_init_memory first --move destructor frida_deinit_memory first --endian little --output lib/agent/libfrida-agent-modulated.so --nm /usr/bin/aarch64-linux-gnu-nm --readelf /usr/bin/readelf --otool ''
'NoneType' object has no attribute 'group'
[2/79] Generating lib/gadget/frida-gadget-modulated with a custom command
FAILED: lib/gadget/libfrida-gadget-modulated.so
/root/frida/frida-core/tools/modulate.py lib/gadget/libfrida-gadget.so --move constructor frida_init_memory first --move constructor frida_on_load last --move destructor frida_deinit_memory first --move destructor frida_on_unload last --strip /root/frida/build/frida_thin-linux-arm64-strip --endian little --output lib/gadget/libfrida-gadget-modulated.so --nm /usr/bin/aarch64-linux-gnu-nm --readelf /usr/bin/readelf --otool ''
'NoneType' object has no attribute 'group'
ninja: build stopped: subcommand failed.
Could not rebuild /root/frida/build/tmp_thin-linux-arm64/frida-core
```
After some investigation I've realized that it was because my `read-elf` was returning `pt_BR` texts, therefore [these regex patterns](https://github.com/frida/frida-core/blob/3d0ce451e624225078f10e4bc23625ba5d065e9d/tools/modulate.py#L12-L15)  were failing :-(
I'm not sure if this is the best place to put this tip, but I reckon it's a good one for non-english natives.