### PR TITLE
build: Ensure Make uses bash for complex operations

### DIFF
--- a/releng/frida.mk
+++ b/releng/frida.mk
@@ -4,6 +4,9 @@ include releng/system.mk
 
 FOR_HOST ?= $(build_os_arch)
 
+# Ensure Make uses bash, so it can execute brace expansions etc.
+SHELL := $(shell which bash)
+
 frida_gum_flags := \
 	--default-library static \
 	$(FRIDA_FLAGS_COMMON) \


### PR DESCRIPTION
Hey,
by default Make uses `sh` which doesn't evaluate complex operations, for example brace expansions.
This has fixed incremental building issues for me.