### PR TITLE
devkit: copy gir file for frida-core kit

### DIFF
--- a/releng/devkit.py
+++ b/releng/devkit.py
@@ -59,13 +59,25 @@ def main():
     if arguments.gir:
         generate_gir(kit, host, outdir)
 
-def generate_gir(kit, host, output_dir):
-    if kit != "frida-core" \
-        or host == "windows":
+def generate_gir(kit, host_arch, output_dir):
+    if kit != "frida-core":
         return
 
-    gir_path = FRIDA_ROOT / "build" / f"tmp-{host}" / kit / "src" / "Frida-1.0.gir"
-    shutil.copy(str(gir_path), output_dir)
+    win_platforms = {
+        "x86_64": "x64-Release",
+        "x86": "Win32-Release",
+    }
+
+    host_arch_splitted = host_arch.split("-")
+    host, h_arch = host_arch_splitted[0], host_arch_splitted[1]
+
+    gir_path = ""
+    if host == "windows":
+        gir_path = str(FRIDA_ROOT / "build" / f"tmp-{host}" / win_platforms[h_arch] / "frida-core" / "Frida-1.0.gir")
+    else:
+        gir_path = str(FRIDA_ROOT / "build" / f"tmp-{host_arch}" / "frida-core" / "src" / "Frida-1.0.gir")
+
+    shutil.copy(gir_path, output_dir)
 
 def generate_devkit(kit, host, flavor, output_dir):
     package, umbrella_header = DEVKITS[kit]

--- a/releng/devkit.py
+++ b/releng/devkit.py
@@ -54,10 +54,10 @@ def main():
 
     outdir.mkdir(parents=True, exist_ok=True)
 
+    generate_devkit(kit, host, flavor, outdir)
+
     if arguments.gir:
         generate_gir(kit, host, outdir)
-
-    generate_devkit(kit, host, flavor, outdir)
 
 def generate_gir(kit, host, output_dir):
     if kit != "frida-core" \

--- a/releng/devkit.py
+++ b/releng/devkit.py
@@ -35,6 +35,7 @@ def main():
     parser.add_argument("host")
     parser.add_argument("outdir")
     parser.add_argument("-t", "--thin", help="build without cross-arch support", action="store_true")
+    parser.add_argument("-g", "--gir", help="copy gir file", action="store_true", default=True)
 
     arguments = parser.parse_args()
 
@@ -53,8 +54,18 @@ def main():
 
     outdir.mkdir(parents=True, exist_ok=True)
 
+    if arguments.gir:
+        generate_gir(kit, host, outdir)
+
     generate_devkit(kit, host, flavor, outdir)
 
+def generate_gir(kit, host, output_dir):
+    if kit != "frida-core" \
+        or host == "windows":
+        return
+
+    gir_path = FRIDA_ROOT / "build" / f"tmp-{host}" / kit / "src" / "Frida-1.0.gir"
+    shutil.copy(str(gir_path), output_dir)
 
 def generate_devkit(kit, host, flavor, output_dir):
     package, umbrella_header = DEVKITS[kit]


### PR DESCRIPTION
Added support for copying .gir file inside the generated devkits. Since the .gir for the `frida-gum` gets generated only for the dynamic library, only `frida-core` devkit creates the .gir file. 