### PR TITLE
Use $(Python) instead of hardcoding python

### DIFF
--- a/releng/frida.props
+++ b/releng/frida.props
@@ -11,8 +11,8 @@
     <Python>python</Python>
     <PythonLocation Condition="'$(PythonLocation)'=='' AND '$(Platform)'=='x64'">$(ProgramFiles)\Python310</PythonLocation>
     <PythonLocation Condition="'$(PythonLocation)'=='' AND '$(Platform)'=='Win32'">$(MSBuildProgramFiles32)\Python310</PythonLocation>
-    <GLibGenmarshal>python $(SolutionDir)build\toolchain-windows\bin\glib-genmarshal</GLibGenmarshal>
-    <GLibMkenums>python $(SolutionDir)build\toolchain-windows\bin\glib-mkenums</GLibMkenums>
+    <GLibGenmarshal>$(Python) $(SolutionDir)build\toolchain-windows\bin\glib-genmarshal</GLibGenmarshal>
+    <GLibMkenums>$(Python) $(SolutionDir)build\toolchain-windows\bin\glib-mkenums</GLibMkenums>
     <ValaCompiler>$(SolutionDir)build\toolchain-windows\bin\valac-0.58.exe</ValaCompiler>
     <ValaFlags>--target-glib=2.74 --vapidir="$(SolutionDir)frida-core\vapi" --vapidir="$(SolutionDir)frida-gum\vapi" --vapidir="$(SolutionDir)build\sdk-windows\$(Platform)-$(Configuration)\share\vala\vapi"</ValaFlags>
   </PropertyGroup>


### PR DESCRIPTION
Use the $(Python) variable instead of hardcoding python for the glib-genmarshal and glib-mkenums paths.