### PR TITLE
fix source-charset to utf-8

### DIFF
--- a/releng/frida.props
+++ b/releng/frida.props
@@ -34,7 +34,7 @@
       <PreprocessorDefinitions>PSAPI_VERSION=1;WIN32;_WINDOWS;WINVER=0x0501;_WIN32_WINNT=0x0501;GUM_STATIC;FFI_STATIC_BUILD;NGTCP2_STATICLIB;NGHTTP2_STATICLIB;V8_GN_HEADER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(OutDir)\$(ProjectName).pdb</ProgramDataBaseFileName>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalOptions>/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <ImportLibrary>$(IntDir)$(ProjectName).lib</ImportLibrary>


### PR DESCRIPTION
I encountered an error when I use VisualStudio2022 to build frida-gadget : [[frida-gadget] Failed to load script: malformed package](https://github.com/frida/frida/issues/2728)

In the end, I found the error source-charset caused this problem. The VisualStudio complied project using the default charset for the environment. However, the result of compile must be utf-8 in order to be connected using frida-tools, which a script coding with python. So we must set charset attribute directly before using VS to build project