### PR TITLE
Update obsolete Apple certificate related chapter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,27 @@ For running the Frida CLI tools, e.g. `frida`, `frida-ls-devices`, `frida-ps`,
 
 ### Apple OSes
 
-First make a trusted code-signing certificate. You can use the guide at
-https://sourceware.org/gdb/wiki/PermissionsDarwin in the sections
-“Create a certificate in the System Keychain” and “Trust the certificate
-for code signing”. You can use the name `frida-cert` instead of `gdb-cert`
-if you'd like.
+First make a trusted code-signing certificate. If you have already used Xcode
+before, chances are you already have an Apple development certificate.
+You can check it with the following command:
 
-Next export the name of the created certificate to relevant environment
+    security find-identity -v -p codesigning
+
+Which will return the certificate in the following format:
+
+    1) XXXXX "Apple Development: user@mail.com (XXXXX)"
+
+If you do not have a certificate, follow this guide: 
+https://help.apple.com/xcode/mac/current/#/dev154b28f09.
+
+Next export the name of your certificate to relevant environment
 variables, and run `make`:
 
-    export MACOS_CERTID=frida-cert
-    export IOS_CERTID=frida-cert
-    export WATCHOS_CERTID=frida-cert
-    export TVOS_CERTID=frida-cert
+    export MACOS_CERTID="Apple Development: user@mail.com (XXXXXXXXXX)"
+    export IOS_CERTID="Apple Development: user@mail.com (XXXXXXXXXX)"
+    export WATCHOS_CERTID="Apple Development: user@mail.com (XXXXXXXXXX)"
+    export TVOS_CERTID="Apple Development: user@mail.com (XXXXXXXXXX)"
     make
-
-To ensure that macOS accepts the newly created certificate, restart the
-`taskgated` daemon:
-
-    sudo killall taskgated
 
 ## Learn more
 


### PR DESCRIPTION
Fixes #3413 

Although the linked issue is closed, it has not been fixed yet. Currently, if we follow the chapter "Apple OSes" in the readme, we will end up with an unusable frida build, because the binaries are not signed properly. At least this is the case on macOS 15.6.1.

The problem is that the generated cert does not grant sufficient privileges and we receive the following error if we try to use frida:

```
$ frida -p 62115
     ____
    / _  |   Frida 0.0.0 - A world-class dynamic instrumentation toolkit
   | (_| |
    > _  |   Commands:
   /_/ |_|       help      -> Displays the help system
   . . . .       object?   -> Display information about 'object'
   . . . .       exit/quit -> Exit
   . . . .
   . . . .   More info at https://frida.re/docs/home/
   . . . .
   . . . .   Connected to Local System (id=local)
Failed to attach: unable to access process with pid 62115 from the current user account
```

After inspecting some logs, we can see that it is a code signature problem:

```
$ sudo log stream --predicate 'process == "kernel" OR process == "taskgated"' --level debug
...
2025-10-09 17:03:16.131131+0200 0xc0478    Default     0x0                  0      0    kernel: (AppleSystemPolicy) ASP: Security policy would not allow process: 68875, /Users/gemesa/.Trash/.frida/frida-b8c6aa9e70375b35aafb852fdec51a83/frida-helper
2025-10-09 17:03:16.136066+0200 0xc047a    Default     0x0                  0      0    kernel: (AppleMobileFileIntegrity) AMFI: '/Users/gemesa/.Trash/.frida/frida-b8c6aa9e70375b35aafb852fdec51a83/frida-helper' does not pass CT evaluation, result: 0xa0500
2025-10-09 17:03:16.136072+0200 0xc047a    Default     0x0                  0      0    kernel: (AppleMobileFileIntegrity) AMFI: '/Users/gemesa/.Trash/.frida/frida-b8c6aa9e70375b35aafb852fdec51a83/frida-helper': Unrecoverable CT signature issue, bailing out.
2025-10-09 17:03:16.136073+0200 0xc047a    Default     0x0                  0      0    kernel: (AppleMobileFileIntegrity) AMFI: code signature validation failed.
...
```

After using an Apple development certificate (generated in Xcode), the problem is resolved:

```
$ frida -p 62115
     ____
    / _  |   Frida 0.0.0 - A world-class dynamic instrumentation toolkit
   | (_| |
    > _  |   Commands:
   /_/ |_|       help      -> Displays the help system
   . . . .       object?   -> Display information about 'object'
   . . . .       exit/quit -> Exit
   . . . .
   . . . .   More info at https://frida.re/docs/home/
   . . . .
   . . . .   Connected to Local System (id=local)
                                                                                
[Local::PID::62115 ]->
```
